### PR TITLE
파이어베이스 관련 모듈의 Hilt 컴포넌트 수정

### DIFF
--- a/feature/main/src/main/java/doingwell/feature/main/app/auth/FirebaseModule.kt
+++ b/feature/main/src/main/java/doingwell/feature/main/app/auth/FirebaseModule.kt
@@ -8,17 +8,15 @@ import com.google.android.gms.auth.api.identity.SignInClient
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.components.SingletonComponent
 import doingwell.feature.main.R
-import javax.inject.Singleton
 
 @Module
-@InstallIn(SingletonComponent::class)
+@InstallIn(ViewModelComponent::class)
 object FirebaseModule {
 
     @Provides
-    @Singleton
     fun provideSignInClient(
         @ApplicationContext context : Context,
     ): SignInClient {
@@ -26,7 +24,6 @@ object FirebaseModule {
     }
 
     @Provides
-    @Singleton
     fun provideSignInRequest(@ApplicationContext context: Context): BeginSignInRequest {
         return BeginSignInRequest.builder()
             .setGoogleIdTokenRequestOptions(


### PR DESCRIPTION
Firebase 모듈은 ViewModel에서만 사용하고 앱 전역의 라이프사이클을 가질 필요가 없어보이므로 
ViewModelComponent를 지정하였고
별다른 스코프를 지정해주지 않았다

This closes #38 