### PR TITLE
 dataSource에서 에러핸들링 하는 코드를 Repository로 위임

### DIFF
--- a/core/data/src/main/java/doingwell/core/data/datasource/remote/DefaultUserRemoteDataSource.kt
+++ b/core/data/src/main/java/doingwell/core/data/datasource/remote/DefaultUserRemoteDataSource.kt
@@ -13,30 +13,18 @@ class DefaultUserRemoteDataSource @Inject constructor(
 ) : UserRemoteDataSource {
 
     override suspend fun insertUserData(userData: UserData): String {
-        return try {
-            database.child(userData.uid).setValue(userData).await()
-            userData.uid
-        } catch (e: Exception) {
-            throw e
-        }
+        database.child(userData.uid).setValue(userData).await()
+        return userData.uid
     }
 
     override suspend fun findUser(uid: String): UserData? {
-        return try {
-            val snapshot = database.child(uid).get().await()
-            snapshot.getValue(UserData::class.java)
-        } catch (e: Exception) {
-            throw e
-        }
+        val snapshot = database.child(uid).get().await()
+        return snapshot.getValue(UserData::class.java)
     }
 
     override suspend fun deleteUser(uid: String): String {
-        return try {
-            database.child(uid).removeValue().await()
-            uid
-        } catch (e: Exception) {
-            throw e
-        }
+        database.child(uid).removeValue().await()
+        return uid
     }
 
 }


### PR DESCRIPTION
에러 핸들링은 repository 단에 위임하는게 적절해보여서 try catch 구문을 삭제했다.